### PR TITLE
Userscripts.org is currently only available on the 8080 port.

### DIFF
--- a/app/views/import/userscriptsorg.html.erb
+++ b/app/views/import/userscriptsorg.html.erb
@@ -4,8 +4,8 @@
 
 <%=form_tag(import_verify_path) do |f|%>
 	<ol>
-		<li><a href="http://userscripts.org/login">Sign in to your userscripts.org account.</a></li>
-		<li><a href="http://userscripts.org/home/settings/profile">Edit your bio</a> to include the a link to your Greasy Fork profile, e.g. <code>&lt;a href="<%=user_url(current_user, :only_path => false)%>"&gt;My profile on Greasy Fork&lt;/a&gt;</code></li>
+		<li><a href="http://userscripts.org:8080/login">Sign in to your userscripts.org account.</a></li>
+		<li><a href="http://userscripts.org:8080/home/settings/profile">Edit your bio</a> to include the a link to your Greasy Fork profile, e.g. <code>&lt;a href="<%=user_url(current_user, :only_path => false)%>"&gt;My profile on Greasy Fork&lt;/a&gt;</code></li>
 		<li>Enter the URL to your userscripts.org profile (where "public profile" links to, for example http://userscripts.org/users/12345): <%=url_field_tag(:url, '', {:size => '50'})%></li>
 		<li><%=submit_tag 'Verify'%></li>
 	</ol>

--- a/app/views/scripts/sync.html.erb
+++ b/app/views/scripts/sync.html.erb
@@ -4,7 +4,7 @@
 			<p>This script is set up to sync from</p>
 			<%=s.url_field(:sync_identifier)%>
 		<% when 2 %>
-			<p>This script is set up to sync from <a href="http://userscripts.org/scripts/show/<%=@script.sync_identifier%>">an entry on userscripts.org</a>.</p>
+			<p>This script is set up to sync from <a href="http://userscripts.org:8080/scripts/show/<%=@script.sync_identifier%>">an entry on userscripts.org</a>.</p>
 		<% when nil %>
 			<p>Greasy Fork can import scripts that already hosted elsewhere. This lets you do things like have your script available for download in multiple places or have it in version control. To enable syncing for your script, provide a URL: <%=s.url_field(:sync_identifier)%></p>
 	<% end %>

--- a/lib/script_importer/userscriptsorg_importer.rb
+++ b/lib/script_importer/userscriptsorg_importer.rb
@@ -8,17 +8,17 @@ module ScriptImporter
 		end
 
 		def self.remote_user_identifier(remote_ownership_url)
-			profile_url_match = /^https?:\/\/userscripts.org\/users\/([0-9]+)(\/.*)?$/.match(remote_ownership_url)
+			profile_url_match = /^https?:\/\/userscripts.org(:8080)?\/users\/([0-9]+)(\/.*)?$/.match(remote_ownership_url)
 			return nil if profile_url_match.nil?
-			return profile_url_match[1]
+			return profile_url_match[2]
 		end
 
 		def self.can_handle_url(url)
-			return /^https?:\/\/userscripts\.org\/scripts\/source\/[0-9]+\.user\.js$/ =~ url
+			return /^https?:\/\/userscripts\.org(:8080)?\/scripts\/source\/[0-9]+\.user\.js$/ =~ url
 		end
 
 		def self.sync_id_to_url(id)
-			"https://userscripts.org/scripts/source/#{id}.user.js"
+			"https://userscripts.org:8080/scripts/source/#{id}.user.js"
 		end
 
 		def self.import_source_name
@@ -33,11 +33,11 @@ module ScriptImporter
 			# loop through each page of results - 20 is a reasonable limit as the most profilic
 			# author on userscripts has < 1000
 			while i < 20
-				content = download("http://userscripts.org/users/#{remote_user_identifier(remote_ownership_url)}/scripts?page=#{i}")
+				content = download("http://userscripts.org:8080/users/#{remote_user_identifier(remote_ownership_url)}/scripts?page=#{i}")
 				page_scripts = content.scan(/<a href="\/scripts\/show\/([0-9]+)[^>]+>([^<]+)/)
 				break if page_scripts.empty?
 				page_scripts.each do |match|
-					scripts[match[0].to_i] = {:name => match[1], :url => "http://userscripts.org/scripts/source/#{match[0]}.user.js"}
+					scripts[match[0].to_i] = {:name => match[1], :url => "http://userscripts.org:8080/scripts/source/#{match[0]}.user.js"}
 				end
 				i = i + 1
 			end


### PR DESCRIPTION
This is a time people are more likely to convert, so update the importer
scripts. We can easily rollback the changes if the site returns.
