### PR TITLE
Add: link to Github issues straight from Help page

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -8,6 +8,7 @@
 	<li><%=link_to 'Rules for code including external scripts', help_external_scripts_path%></li>
 	<li><%=link_to 'Allowed markup for posting on Greasy Fork', help_allowed_markup_path%></li>
 	<li><%=link_to 'How Greasy Fork will rewrite posted scripts', help_rewriting_path%></li>
+	<li><%=link_to 'Report issue or post idea for Greasy Fork itself', 'https://github.com/JasonBarnabe/greasyfork/issues'%></li>
 	<li><%=link_to 'Contact someone', help_contact_path%></li>
 	<li><%=link_to 'Credits', help_credits_path%></li>
 </ul>


### PR DESCRIPTION
I think now link to Github page is buried too deep in help pages.
