### PR TITLE
In Help, link directly to GitHub repo

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -30,3 +30,5 @@
 		<li><%=link_to 'Disallowed code patterns', help_disallowed_code_path%></li>
 	</ul>
 <% end %>
+
+<p>The Greasy Fork website is open-source (GPL licensed). You can <a href="https://github.com/JasonBarnabe/greasyfork"></a>view its source on GitHub</a>.</p>


### PR DESCRIPTION
I expected the site to be open source, and out of curiosity, I was looking for a link to Greasy Fork’s source code on the site. Normally such a link would be on an About page or in the site footer, but Greasy Fork doesn’t have either of those. I eventually found the GitHub repo within the link “Report issue or post idea for Greasy Fork itself”, by hovering over the link and noticing “github.com” in the URL. But that link is specifically for issues – there is no link that actually mentions that this site is open source. Thus, I added this paragraph in Help.

It’s not another bulleted list item because I also wanted the statement that this site is open source, for clarity. So I put it in a separate paragraph.
