### PR TITLE
Refactor “Applies to” list display on script#show page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -213,6 +213,21 @@ nav li + li {
 #script-applies-to dd {
 	display: inline;
 }
+#script-applies-to ul {
+	display: inline;
+	padding-left: 0;
+	list-style: none;
+}
+#script-applies-to li {
+	display: inline;
+}
+#script-applies-to li:after {
+	content: ", ";
+}
+#script-applies-to li:last-child:after {
+	content: "";
+}
+
 
 #additional-info > h3 {
 	margin-bottom: 0;

--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -23,5 +23,35 @@ module ScriptsHelper
 		end
 		return ("<li class=\"script-list-option#{is_link ? '' : ' script-list-current'}\">" + l + '</li>').html_safe
 	end
+	
+	def script_applies_to_list_contents(script, by_sites)
+		sats_with_domains, sats_without_domains = script.script_applies_tos.partition{|sat|sat.domain}
+		(
+		sats_with_domains.map{ |sat|			
+			content_for_script_applies_to_that_has_domain(sat, count_of_other_scripts_with_sat(sat, script, by_sites))
+		} +
+		sats_without_domains.map{ |sat| content_tag(:code, sat.text) }
+		)
+	end
+	
+private
+	
+	def content_for_script_applies_to_that_has_domain(sat, count_of_other_scripts)
+		if count_of_other_scripts > 0
+			title = t('scripts.applies_to_link_title', {:count => count_of_other_scripts, :site => sat.text})
+			link_to(sat.text, by_site_scripts_path(:site => sat.text), {:title => title})
+		else
+			sat.text
+		end
+	end
+	
+	def count_of_other_scripts_with_sat(script_applies_to, script, by_sites)
+		if by_sites[script_applies_to.text].nil?
+			0
+		else
+			# take this one out of the count if it's a listable
+			(by_sites[script_applies_to.text][:scripts] - (script.listable? ? 1 : 0))
+		end
+	end
 
 end

--- a/app/views/scripts/show.html.erb
+++ b/app/views/scripts/show.html.erb
@@ -108,16 +108,11 @@
 			<% if @script.script_applies_tos.empty? %>
 				<%=t('scripts.applies_to_all')%>
 			<% else %>
-				<%=
-					(
-					@script.script_applies_tos.select{|s|s.domain}.map{ |s|
-						# count of other scripts - take this one out of the count if it's a listable
-						script_count = @by_sites[s.text].nil? ? 0 : (@by_sites[s.text][:scripts] - (@script.listable? ? 1 : 0))
-						next link_to(h(s.text), by_site_scripts_path(:site => s.text), {:title => t('scripts.applies_to_link_title', {:count => script_count, :site => s.text})}) if script_count > 0
-						next h(s.text)
-					} +
-					@script.script_applies_tos.select{|s|!s.domain}.map{|s| "<code>#{h(s.text)}</code>".html_safe}
-					).join(', ').html_safe%>
+				<ul>
+					<% script_applies_to_list_contents(@script, @by_sites).each do |script_applies_to_content| %>
+						<li><%=script_applies_to_content%></li>
+					<% end %>
+				</ul>
 			<% end %>
 		</dd>
 	</dl>


### PR DESCRIPTION
Moved complicated Ruby code from the view into a helper, then split that helper in multiple, easier-to-understand methods.

Removed unnecessary `h()` calls – Rails automatically escapes unescaped text. Also changed manual HTML building with `html_safe` to use `content_tag`.

Changed HTML representation of the list – made the list an actual `<ul>`, with CSS to make it display as comma-separated.

I tried out this change [on a local install](https://github.com/JasonBarnabe/greasyfork/wiki/Running-Greasy-Fork-locally) with test data, and everything still seems to work:

![screenshot of working refactored Applies To in Greasy Fork](https://cloud.githubusercontent.com/assets/79168/3936836/bd999abc-24a6-11e4-9007-47e162b3ff8d.png)
