### PR TITLE
Wrap inline CODE tags in FireFox

### DIFF
--- a/misc/vanilla-theme/design/custom.css
+++ b/misc/vanilla-theme/design/custom.css
@@ -16,6 +16,12 @@ body, .SiteTitle, select, input {
 pre {
 	letter-spacing: normal;
 }
+code {
+	white-space: pre-wrap;
+}
+pre code {
+	white-space: pre;
+}
 body:not(.Settings) #Head {
 	background-color: #670000;
 	padding-top: 0 !important;


### PR DESCRIPTION
Unlike Chrome, FireFox doesn't force wrapping of long lines inside code blocks with `white-space: pre` so such lines break the site layout.