### PR TITLE
Add 0.1s shadow transition to install-area buttons

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -246,6 +246,7 @@ nav .with-submenu:hover > a::after, nav .with-submenu > a:focus::after {
 	margin-bottom: 1em;
 }
 #install-area .install-link:hover, #install-area .install-link:focus, #install-area .install-help-link:hover, #install-area .install-help-link:focus {
+	transition: box-shadow 0.1s;
 	box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19);
 }
 .install-link, .install-link:visited, .install-link:active, .install-link:hover, .install-help-link {


### PR DESCRIPTION
I added a 0.1 seconds shadow transition to install-area buttons. It looks very good.