### PR TITLE
Improve install-area button shadow

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -246,10 +246,11 @@ nav .with-submenu:hover > a::after, nav .with-submenu > a:focus::after {
 	margin-bottom: 1em;
 }
 #install-area .install-link:hover, #install-area .install-link:focus, #install-area .install-help-link:hover, #install-area .install-help-link:focus {
-	transition: box-shadow 0.1s;
+	transition: box-shadow 0.2s;
 	box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19);
 }
 .install-link, .install-link:visited, .install-link:active, .install-link:hover, .install-help-link {
+	transition: box-shadow 0.2s;
 	display: inline-block;
 	background-color: #005200;
 	padding: 0.5em 1em;


### PR DESCRIPTION
I improved the install-area button shadow transition. This time i made a gif to show you the effect.
![chrome-capture](https://user-images.githubusercontent.com/32852493/50574141-fb268b80-0dc0-11e9-8f2a-c97112d3e341.gif)

I also noticed that if you remove the border of text-content or you change the border color to white and then you add this box-shadow, you can get a really nice cardboard effect:

`box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);`