### PR TITLE
Add shadow to new_user form submit buttons

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -835,7 +835,8 @@ form.new_user input[type="submit"] {
 	color: #fff;
 	background-color: #670000;
 	background-image: linear-gradient(#990000, #670000);
-	border: 1px solid #ddd;
+	border: 0px solid #ddd;
+    	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 	border-radius: 3px;
 }
 form.new_user ~ br {


### PR DESCRIPTION
Changed border size to 0px and added box shadow.
![1](https://user-images.githubusercontent.com/32852493/50613856-cb10e280-0ebd-11e9-8e02-e35ce94c1e03.jpg)

This also applies for other buttons like restore password button.