### PR TITLE
Improve current tab shadow

### DIFF
--- a/app/assets/stylesheets/tabs.css
+++ b/app/assets/stylesheets/tabs.css
@@ -23,7 +23,7 @@
   box-shadow: inset 1px 0 rgba(0, 0, 0, 0.1), inset -1px 0 rgba(0, 0, 0, 0.1), inset 0 -1px rgba(0, 0, 0, 0.1);
 }
 .tabs .current {
-  box-shadow: inset 1px 0 rgba(0, 0, 0, 0.1), inset -1px 0 rgba(0, 0, 0, 0.1), inset 0 -1px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 5px 5px 5px -3px rgba(0, 0, 0, 0.2), inset -1px 0 rgba(0, 0, 0, 0.1), inset 0 -1px rgba(0, 0, 0, 0.1);
   border-top: 7px solid #990000;
 }
 .tabs li:not(.current) a {


### PR DESCRIPTION
Improved current tab shadow.
**Before:**
![before](https://user-images.githubusercontent.com/32852493/51486381-4cea8200-1d7f-11e9-93ca-7cb61f18dd05.png)
**After**
![after](https://user-images.githubusercontent.com/32852493/51486401-596eda80-1d7f-11e9-8d06-ce32f88aafb6.png)
