### PR TITLE
Fixed image position in external-login buttons

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -683,7 +683,7 @@ a.self-link, a.self-link:visited {
 	border-radius: 2px;
 	background-repeat: no-repeat;
 	background-size: 16px 16px;
-	background-position: 5px 4px;
+	background-position: 5px 2px;
 }
 .external-login-container {
 	display: inline-block;


### PR DESCRIPTION
**Before:**
![before](https://user-images.githubusercontent.com/32852493/57810015-3658a400-773d-11e9-87ba-914b6d9b6741.png)
**After:**
![after](https://user-images.githubusercontent.com/32852493/57810033-3bb5ee80-773d-11e9-8cb1-d665161838b7.png)

Tested in Google Chrome and Edge