### PR TITLE
Added meta tag for twitter card

### DIFF
--- a/app/views/layouts/scripts.html.erb
+++ b/app/views/layouts/scripts.html.erb
@@ -49,6 +49,7 @@
 <% end %>
 
 <% content_for(:head_bottom) do %>
+  <meta name="twitter:card" content="summary">
   <meta property="og:title" content="<%= @script.default_name %>">
   <meta property="og:url" content="<%= script_url(@script, locale: nil) %>">
   <% if @script_version %>


### PR DESCRIPTION
Spec: https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started
Display image like: https://www.google.co.jp/search?tbm=isch&q=twitter:card

cf. https://github.com/JasonBarnabe/greasyfork/issues/839