### PR TITLE
Added og:description for Open Graph Twitter card

### DIFF
--- a/app/views/layouts/scripts.html.erb
+++ b/app/views/layouts/scripts.html.erb
@@ -52,6 +52,7 @@
   <meta name="twitter:card" content="summary">
   <meta property="og:title" content="<%= @script.default_name %>">
   <meta property="og:url" content="<%= script_url(@script, locale: nil) %>">
+  <meta property="og:description" content="<%= @script.description(I18n.locale) %>">
   <% if @script_version %>
     <%# Same as in screenshots/_show.html.erb %>
     <% attachments = @script_version.attachments.includes(:blob).load %>


### PR DESCRIPTION
I18n.locale could be treated if you link to locale-included URLs, and it may be ignored with no-locale URLs.
I think it doesn't depend on the "og:URL" with no locale, but it depends on an actual tweeted URL.

(sorry for multiple pull requests)

cf. #839