### PR TITLE
wrap tabs for small devices/windows

### DIFF
--- a/app/javascript/stylesheets/tabs.css
+++ b/app/javascript/stylesheets/tabs.css
@@ -6,6 +6,7 @@
   display: flex;
   position: relative;
   top: -3.5px;
+  flex-wrap: wrap;
 }
 .tabs > * {
   align-items: stretch;


### PR DESCRIPTION
Currently the tabs are not wrapped, so you have to scroll to the right of the page to see the rest of the tabs:
![grafik](https://user-images.githubusercontent.com/6975881/210255105-01a5ea55-b061-4b14-b298-d896cefbe605.png)

This is especially bad looking at smartphones (here a screenshot zoomed out, so I could click at the last item):
![grafik](https://user-images.githubusercontent.com/6975881/210255332-9f7c56fb-4532-4159-9d62-f269d08eae1b.png)

With this PR the tabs are now wraped at the end of the page, so all tabs stay inside the main page:
![grafik](https://user-images.githubusercontent.com/6975881/210255649-3f62932c-d784-4780-9142-d2e99e807c4c.png)
