### PR TITLE
To make the wording more easily understandable

### DIFF
--- a/app/views/users/webhook_info.html.erb
+++ b/app/views/users/webhook_info.html.erb
@@ -37,9 +37,9 @@
   </dd>
   <dt>Which events would you like to trigger this webhook?</dt>
   <dd>
-    To update <%= site_name %> on all pushes, choose "Just the push event".<br>
-    To update <%= site_name %> only on releases, choose "Let me select individual events", uncheck "Pushes", and check "Releases".<br>
-    (In either case, <%= site_name %> will be looking for modified files in these events.)
+    <p>1. If you want to update <%= site_name %> whenever there is any push event, select "Just the push event."</p>
+    <p>2. If you only want to update <%= site_name %> when there are releases, choose "Let me select individual events," uncheck "Pushes," and check "Releases."</p>
+    <b><p>(In either case, <%= site_name %> will only check for modified files in the specified events.)</p></b>
   </dd>
 
   <dt>Active</dt>


### PR DESCRIPTION
Follow-up for commit a1ecbdc74caa3e9e151344ad91578dfe534f1447

It is to make the wording more easily understandable

@JasonBarnabe 