### PR TITLE
Added examples for Subresource Integrity (SRI) used in GreasyFork

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -793,6 +793,13 @@ bg:
         title: Скриптове с проверка за целостта на подресурса
         content_html: |
             <p>Използването на <code>@require</code> и <code>@resource</code> с URLи с %{mdn_sri_link:проверка на подресурса} в %{tm_sri_link:Tampermonkey формат} е позволено.</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: Разрешени външни кодове
         content_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1102,6 +1102,13 @@ en:
         title: Scripts with subresource integrity hashes
         content_html: |
           <p>Use of <code>@require</code> and <code>@resource</code> with URLs with %{mdn_sri_link:subresource integrity} in the %{tm_sri_link:Tampermonkey format} is allowed.</p>
+          <pre><code lang="js">
+          // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+          // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+          // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+          // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+          // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+          </code></pre>
       allowed_external_codes:
         heading: Allowed external codes
         content_html: |

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -806,6 +806,13 @@ fr:
         title: Scripts avec hachages d'intégrité des sous-ressources
         content_html: |
             <p>L'utilisation de <code>@require</code> et <code>@resource</code> avec des URL avec %{mdn_sri_link:intégrité des sous-ressources} au %{tm_sri_link:Tampermonkey format} est autorisée.</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: Codes externes autorisés
         content_html: |

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -758,6 +758,13 @@ ja:
         title: サブリソースの整合用のハッシュを使用したスクリプト
         content_html: |
             <p><code>@require</code> と <code>@resource</code> を%{mdn_sri_link:サブリソースの完全性}を保証する目的で %{tm_sri_link:Tampermonkey の形式}で使用することは許可されています。</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: 許可される外部のコード
         content_html: |

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -794,6 +794,13 @@ nl:
         title: Scripts met subbron-controlesommen
         content_html: |
             <p>Het gebruik van <code>@require</code> en <code>@resource</code> in combinatie met url's met %{mdn_sri_link:subbron-integriteit} in de %{tm_sri_link:Tampermonkey-opmaak} is toegestaan.</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: Toegestane externe codes
         content_html: |

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -753,6 +753,13 @@ pt-BR:
         title: Códigos com chaves de integridade de sub recursos
         content_html: |
             <p>O uso de <code>@require</code> e <code>@resource</code>com URLs com %{mdn_sri_link:subresource integrity} em %{tm_sri_link:Tampermonkey format} é permitido.
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: Códigos externos permitidos
         content_html: |

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -819,6 +819,13 @@ ru:
         title: Скрипты с subresource integrity hashes
         content_html: |
             <p>Разрешены <code>@require</code> и <code>@resource</code> с URL с %{mdn_sri_link:subresource integrity} в %{tm_sri_link:формате Tampermonkey}.</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: Разрешённые внешние скрипты
         content_html: |

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -815,6 +815,13 @@ sk:
         title: Skripty s hashmi integrity čiastkových zdrojov
         content_html: |
             <p>Použitie <code>@require</code> a <code>@resource</code> s adresami URL s %{mdn_sri_link:integrita čiastkových zdrojov} vo formáte %{tm_sri_link:Tampermonkey} je povolené.</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: Povolené externé kódy
         content_html: |

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -751,6 +751,13 @@ zh-CN:
         title: 附有子资源完整性散列的脚本
         content_html: |
             <p>允许使用 %{tm_sri_link:Tampermonkey 格式} 下的有%{mdn_sri_link:子资源完整性}的 <code>@require</code> 和<code>@resource</code> URL。</p>
+            <pre><code lang="js">
+            // @resource SRIsecured1 http://example.com/favicon1.ico#md5=ad34bb...
+            // @resource SRIsecured2 http://example.com/favicon2.ico#md5=ac3434...,sha256=23fd34...
+            // @require              https://code.jquery.com/jquery-2.1.1.min.js#md5=45eef...
+            // @require              https://code.jquery.com/jquery-2.1.2.min.js#md5=ac56d...,sha256=6e789...
+            // @require              https://code.jquery.com/jquery-3.6.0.min.js#sha256=/xUj+3OJU...ogEvDej/m4=
+            </code></pre>
       allowed_external_codes:
         heading: 允许的外部代码
       libraries:


### PR DESCRIPTION
see https://greasyfork.org/en/discussions/greasyfork/153469.

Regarding Subresource Integrity (SRI), TM supports both `xxx.js#sha256-xxxx` and `xxx.js#sha256=xxxx`, while GreasyFork only supports `xxx.js#sha256=xxxx` format.

Better to have example coding instead of just referring the external site.