### PR TITLE
Add link to Violentmonkey help

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -4,8 +4,9 @@
 <ul>
   <li><%= link_to t('help.installing_user_scripts.title'), help_installing_user_scripts_path %></li>
   <li><%= link_to t('help.installing_user_styles.title'), help_installing_user_styles_path %></li>
-  <li><%= link_to t('help.help_with_tampermonkey'), 'https://www.tampermonkey.net/faq.php' %></li>
   <li><%= link_to t('help.help_with_greasymonkey'), 'https://wiki.greasespot.net/Troubleshooting_(Users)' %></li>
+  <li><%= link_to t('help.help_with_tampermonkey'), 'https://www.tampermonkey.net/faq.php' %></li>
+  <li><%= link_to t('help.help_with_violentmonkey'), 'https://violentmonkey.github.io/guide/creating-a-userscript/' %></li>
 </ul>
 
 <h3><%= t('help.sections.development') %></h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1285,6 +1285,7 @@ en:
     # link to greasemonkey docs
     help_with_greasymonkey: "Help with Greasemonkey"
     help_with_tampermonkey: "Help with Tampermonkey"
+    help_with_violentmonkey: "Help with Violentmonkey"
     contact:
       # title of contact page
       title: "Contact someone"


### PR DESCRIPTION
Similar to the user help links for Tampermonkey and Greasemonkey. Violentmonkey is newer but open-source and actively maintained.