### PR TITLE
Sync Chinese iOS browser lists with English locale

### DIFF
--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -542,6 +542,7 @@ zh-CN:
           <ul>
           <li>Safari：%{safari_tampermonkey_link:Tampermonkey} 或 %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}：（无须安装额外软件）
+          <li>%{teak_link:Teak}：（无须安装额外软件）
           </ul>
     installing_step2_header: "第 2 步：安装一个用户脚本"
     installing_step2_caption: "用户脚本的安装按钮"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -520,6 +520,7 @@ zh-TW:
           <ul>
           <li>Safari：%{safari_tampermonkey_link:Tampermonkey} 或 %{safari_userscripts_link:Userscripts}</li>
           <li>%{gear_link:Gear}：（不需要其他軟體）
+          <li>%{teak_link:Teak}：（不需要其他軟體）
           </ul>
     installing_step2_header: "第二步：安裝使用者腳本"
     installing_step2_caption: "使用者腳本的安裝按鈕"


### PR DESCRIPTION
## Summary

- Add the existing English Teak iOS browser entry to the Simplified Chinese locale
- Add the same Teak entry to the Traditional Chinese locale
- Keep the Chinese iOS browser lists aligned with the English source strings

## Testing

- Not run; locale-only text update