### PR TITLE
Fix preview result in dark theme

### DIFF
--- a/app/javascript/stylesheets/colors.css
+++ b/app/javascript/stylesheets/colors.css
@@ -40,6 +40,8 @@
   --alert-border-color: #FFEB3B;
   --alert-text-color: black;
 
+  --preview-result-background-color: #FFFFAA;
+
   --chart-background-color: #dcdcdc;
   --chart-border-color: rgb(220,220,220);
 
@@ -136,6 +138,8 @@
     --alert-background-color: #3D3D00;
     --alert-border-color: #A19000;
     --alert-text-color: white;
+
+    --preview-result-background-color: #4D4D00;
 
     --chart-background-color: #606060;
     --chart-border-color: #454545;

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -331,7 +331,7 @@ label.subselection-radio-title {
 }
 .preview-result {
   display: none;
-  background-color: #FFA;
+  background-color: var(--preview-result-background-color);
   padding: 0.5em;
 }
 


### PR DESCRIPTION
Previously the preview of any script > Admin > Source Syncing was difficult to see with dark mode:
<img width="1457" height="245" alt="grafik" src="https://github.com/user-attachments/assets/43c39aaf-7878-4be0-94f6-48bc10d88e2c" />

With this PR the text will be readable in dark mode and unchanged in light mode:
<img width="1457" height="245" alt="grafik" src="https://github.com/user-attachments/assets/9bf85d11-cd29-49cd-80e8-a7be05c7f01a" />

