### PR TITLE
Fix active state detection for script list filters

### DIFF
--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -19,12 +19,7 @@ module ScriptsHelper
     # sets can have a different default
     sort_param_to_use = (sort == default_sort) ? nil : sort
     rel ||= (set.present? || filter_locale.present?) ? :nofollow : nil
-    current_language = params[:language]
-    current_language = nil if current_language.blank? && language == 'js' && params[:controller] == 'scripts'
-
-    set_matches = set.nil? ? params[:set].nil? : set.to_s == params[:set].to_s
-
-    if sort == params[:sort] && site == params[:site] && set_matches && language == current_language && by == params[:by]
+    if sort == params[:sort] && site == params[:site] && set == params[:set].to_i && language == params[:language].presence && by == params[:by]
       l = label
       is_link = false
     elsif is_libraries

--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -19,7 +19,12 @@ module ScriptsHelper
     # sets can have a different default
     sort_param_to_use = (sort == default_sort) ? nil : sort
     rel ||= (set.present? || filter_locale.present?) ? :nofollow : nil
-    if sort == params[:sort] && site == params[:site] && set == params[:set] && language == params[:language] && by == params[:by]
+    current_language = params[:language]
+    current_language = nil if current_language.blank? && language == 'js' && params[:controller] == 'scripts'
+
+    set_matches = set.nil? ? params[:set].nil? : set.to_s == params[:set].to_s
+
+    if sort == params[:sort] && site == params[:site] && set_matches && language == current_language && by == params[:by]
       l = label
       is_link = false
     elsif is_libraries


### PR DESCRIPTION
## Summary

Fixes active state detection for selected script sets in script listings.

The previous comparison used a direct equality check between `set` and `params[:set]`, which could fail due to differing types (`Integer` vs `String`). As a result, a selected script set (for example, a favorites set) would not appear as active even when it was currently applied.

Additionally, normalize the default JavaScript language filter state so the active filter is detected correctly when `params[:language]` is blank.

## Visual Example

### Before

<img width="446" height="266" alt="before" src="https://github.com/user-attachments/assets/2e6c8794-3c2a-43a3-98c5-b4abda62b90f" />

The selected "Favorites" script set is displayed as a normal link instead of the active item.

### After

<img width="446" height="266" alt="after" src="https://github.com/user-attachments/assets/b841e58e-ad97-42e4-b7f3-348733a9c708" />

The selected script set is correctly highlighted as active.

## Testing

* Reproduced the issue locally with a favorite script set.
* Verified that the selected script set now appears as active.
* Ran the existing controller test suite successfully.

Tests:

```bash
bundle exec rails test test/controllers/scripts_controller_test.rb
```
