### PR TITLE
Fix active state detection without script set

### DIFF
--- a/app/helpers/scripts_helper.rb
+++ b/app/helpers/scripts_helper.rb
@@ -19,7 +19,7 @@ module ScriptsHelper
     # sets can have a different default
     sort_param_to_use = (sort == default_sort) ? nil : sort
     rel ||= (set.present? || filter_locale.present?) ? :nofollow : nil
-    if sort == params[:sort] && site == params[:site] && set == params[:set].to_i && language == params[:language].presence && by == params[:by]
+    if sort == params[:sort] && site == params[:site] && set.to_i == params[:set].to_i && language == params[:language].presence && by == params[:by]
       l = label
       is_link = false
     elsif is_libraries


### PR DESCRIPTION
Sorry for the follow-up. I missed the no-script-set case in the previous change.

When no script set is selected, `set` is `nil` while `params[:set].to_i` is `0`, so `set == params[:set].to_i` becomes `nil == 0` and active states without a script set no longer match.

This changes the comparison to `set.to_i == params[:set].to_i`, which restores the no-script-set case while keeping the selected script set behavior.

## Testing

Tested locally on a user profile with a local test script:

* normal profile script list
* profile with Favorites selected
* Favorites → All
* selector active states after changing options

I couldn’t test `/fr/scripts` locally because the global script list needs Elasticsearch/Searchkick, and Elasticsearch wasn’t running in my local setup.