### PR TITLE
Use native forms for discussion subscriptions

### DIFF
--- a/app/javascript/stylesheets/forum.css
+++ b/app/javascript/stylesheets/forum.css
@@ -171,6 +171,18 @@ a.discussion-title, .notification-list-item a {
 .discussion-actions, .notification-actions {
   font-size: smaller;
 }
+.discussion-subscription-links button {
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: 0;
+  color: var(--link-color);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
 .discussion-subscribed .discussion-subscribe {
   display: none;
 }

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -38,8 +38,8 @@
   <% if current_user && !@discussion.soft_deleted? %>
     <div class="discussion-actions">
       <div class="discussion-subscription-links <%= current_user.subscribed_to?(@discussion) ? 'discussion-subscribed' : 'discussion-not-subscribed' %>">
-        <%= link_to t('discussions.subscribe'), scoped_subscribe_path(@discussion), data: { turbo: true, turbo_method: :POST }, class: 'discussion-subscribe' %>
-        <%= link_to t('discussions.unsubscribe'), scoped_unsubscribe_path(@discussion), data: { turbo: true, turbo_method: :POST }, class: 'discussion-unsubscribe' %>
+        <%= button_to t('discussions.subscribe'), scoped_subscribe_path(@discussion), method: :post, form_class: 'inline-form', class: 'discussion-subscribe' %>
+        <%= button_to t('discussions.unsubscribe'), scoped_unsubscribe_path(@discussion), method: :post, form_class: 'inline-form', class: 'discussion-unsubscribe' %>
       </div>
     </div>
   <% end %>

--- a/test/system/discussions/discussions_test.rb
+++ b/test/system/discussions/discussions_test.rb
@@ -121,13 +121,14 @@ class DiscussionsTest < ApplicationSystemTestCase
     login_as(user, scope: :user)
     discussion = discussions(:non_script_discussion)
     visit discussion.url
+    assert_selector '.discussion-subscription-links form[method="post"] button.discussion-subscribe', text: 'Subscribe'
     assert_difference -> { DiscussionSubscription.count } => 1 do
       click_on 'Subscribe'
-      assert_selector 'a', text: 'Unsubscribe'
+      assert_button 'Unsubscribe'
     end
     assert_difference -> { DiscussionSubscription.count } => -1 do
       click_on 'Unsubscribe'
-      assert_selector 'a', text: 'Subscribe'
+      assert_button 'Subscribe'
     end
   end
 

--- a/test/system/discussions/script_discussions_test.rb
+++ b/test/system/discussions/script_discussions_test.rb
@@ -120,13 +120,14 @@ class ScriptDiscussionsTest < ApplicationSystemTestCase
     login_as(user, scope: :user)
     discussion = discussions(:script_discussion)
     visit discussion.url
+    assert_selector '.discussion-subscription-links form[method="post"] button.discussion-subscribe', text: 'Subscribe'
     assert_difference -> { DiscussionSubscription.count } => 1 do
       click_on 'Subscribe'
-      assert_selector 'a', text: 'Unsubscribe'
+      assert_button 'Unsubscribe'
     end
     assert_difference -> { DiscussionSubscription.count } => -1 do
       click_on 'Unsubscribe'
-      assert_selector 'a', text: 'Subscribe'
+      assert_button 'Subscribe'
     end
   end
 end


### PR DESCRIPTION
## Summary

- render discussion subscribe and unsubscribe controls as native POST forms so they work without Turbo
- preserve the existing inline link presentation and enhanced behavior
- cover the generated POST form and both subscription transitions for script and non-script discussions

Fixes #1551

## Testing

- `bundle exec rails test test/system/discussions/discussions_test.rb test/system/discussions/script_discussions_test.rb` (13 runs, 97 assertions)
- `bundle exec rubocop --no-parallel` (419 files)
- `bundle exec erb_lint app/views/discussions/show.html.erb`
- `bundle exec rails assets:precompile --trace`
- `bundle exec rails test:all` (734 runs, 0 errors; six unrelated install-navigation timing failures under local Chrome 150, plus one URL-import download timeout that passed when rerun alone)