### PR TITLE
Fix webhook syncing for private GitLab repos

### DIFF
--- a/app/controllers/concerns/webhooks.rb
+++ b/app/controllers/concerns/webhooks.rb
@@ -108,6 +108,22 @@ module Webhooks
     return changed_files, params[:project][:git_http_url]
   end
 
+  # A sync identifier carrying a token can't be fetched by cloning the repository
+  # anonymously, so its contents have to come from the URL. Additional info
+  # attributes have their own sync identifiers, and a changed file can match only
+  # those, so both have to be considered.
+  def private_sync?(info)
+    (info[:scripts].to_a + info[:script_attributes].to_a).any? do |record|
+      record.sync_identifier&.include?('private_token')
+    end
+  end
+
+  # The identifier to download a changed file from. A file that matched only an
+  # additional info attribute has no scripts.
+  def sync_identifier_for(info)
+    (info[:scripts].first || info[:script_attributes].first).sync_identifier
+  end
+
   # Adds scripts and script_attributes keys to changed_files.
   # - user
   # - changed_files - a Hash of URL to Hash
@@ -141,12 +157,12 @@ module Webhooks
     end
 
     # Get the contents of the files. Some we will have to pull from the URL if it's a private repo.
-    pull_from_url, pull_from_git = changed_files.partition { |_k, v| v[:scripts].any? { |s| s.sync_identifier.include?('private_token') } }
+    pull_from_url, pull_from_git = changed_files.partition { |_k, v| private_sync?(v) }
     pull_from_url = pull_from_url.to_h
     pull_from_git = pull_from_git.to_h
 
     pull_from_url.values.each do |h|
-      h[:content] = ScriptImporter::BaseScriptImporter.download(h[:scripts].first.sync_identifier)
+      h[:content] = ScriptImporter::BaseScriptImporter.download(sync_identifier_for(h))
     end
 
     if pull_from_git.any?

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -41,7 +41,10 @@ class Gitlab
         "#{repo_url}/raw/#{branch}/#{file}",
         "#{repo_url}/-/raw/#{branch}/#{file}",
         { prefix: "https://gitlab.com/api/v4/projects/#{project_id}/repository/files/#{file}/raw?ref=#{branch}" },
-      ]
+        # The files API only serves a URL-encoded path, so anything in a
+        # subdirectory is stored with %2F separators and won't match the form above.
+        { prefix: "https://gitlab.com/api/v4/projects/#{project_id}/repository/files/#{ERB::Util.url_encode(file)}/raw?ref=#{branch}" },
+      ].uniq
     end
 
     def file_from_root_for_url(url, repo_url)

--- a/test/integration/gitlab_webhook_test.rb
+++ b/test/integration/gitlab_webhook_test.rb
@@ -131,6 +131,77 @@ class GitlabWebhookTest < ActionDispatch::IntegrationTest
     }
   JSON
 
+  PRIVATE_PUSH_BODY = <<~JSON.freeze
+    {
+    "object_kind": "push",
+    "event_name": "push",
+    "before": "c07b16267070314ee1da3d77f24c727378614125",
+    "after": "ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
+    "ref": "refs/heads/main",
+    "ref_protected": true,
+    "checkout_sha": "ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
+    "message": null,
+    "user_id": 123456,
+    "user_name": "MY NAME",
+    "user_username": "430i",
+    "user_email": "",
+    "user_avatar": "https://secure.gravatar.com/avatar/d1a4df204cd9d900bd92207459885b9d?s=80&d=identicon",
+    "project_id": 456789,
+    "project": {
+    "id": 456789,
+    "name": "repository",
+    "description": "",
+    "web_url": "https://gitlab.com/username-or-group/repository",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:username-or-group/repository.git",
+    "git_http_url": "https://gitlab.com/username-or-group/repository.git",
+    "namespace": "namespace",
+    "visibility_level": 0,
+    "path_with_namespace": "username-or-group/repository",
+    "default_branch": "main",
+    "ci_config_path": "",
+    "homepage": "https://gitlab.com/username-or-group/repository",
+    "url": "git@gitlab.com:username-or-group/repository.git",
+    "ssh_url": "git@gitlab.com:username-or-group/repository.git",
+    "http_url": "https://gitlab.com/username-or-group/repository.git"
+    },
+    "commits": [
+    {
+    "id": "ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
+    "message": "debug: update\\n",
+    "title": "debug: update",
+    "timestamp": "2024-01-06T00:43:53+01:00",
+    "url": "https://gitlab.com/username-or-group/repository/-/commit/ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
+    "author": {
+    "name": "MY NAME",
+    "email": "[REDACTED]"
+    },
+    "added": [
+
+    ],
+    "modified": [
+    "script.user.js"
+    ],
+    "removed": [
+
+    ]
+    }
+    ],
+    "total_commits_count": 1,
+    "push_options": {
+    },
+    "repository": {
+    "name": "repository",
+    "url": "git@gitlab.com:username-or-group/repository.git",
+    "description": "",
+    "homepage": "https://gitlab.com/username-or-group/repository",
+    "git_http_url": "https://gitlab.com/username-or-group/repository.git",
+    "git_ssh_url": "git@gitlab.com:username-or-group/repository.git",
+    "visibility_level": 0
+    }
+    }
+  JSON
+
   def push_webhook_request(user, secret: nil, body: CHANGE_BODY)
     post user_webhook_url(user_id: user.id),
          headers: { 'Content-Type' => 'application/json', 'X-Gitlab-Event' => 'Push Hook', 'X-Gitlab-Token' => secret || user.webhook_secret, 'Connection' => 'close', 'Host' => 'greasyfork.org', 'X-Forwarded-Proto' => 'https', 'X-Forwarded-For' => '35.231.231.98' },
@@ -178,76 +249,7 @@ class GitlabWebhookTest < ActionDispatch::IntegrationTest
   end
 
   def test_webhook_to_private_url
-    json = <<~JSON
-      {
-      "object_kind": "push",
-      "event_name": "push",
-      "before": "c07b16267070314ee1da3d77f24c727378614125",
-      "after": "ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
-      "ref": "refs/heads/main",
-      "ref_protected": true,
-      "checkout_sha": "ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
-      "message": null,
-      "user_id": 123456,
-      "user_name": "MY NAME",
-      "user_username": "430i",
-      "user_email": "",
-      "user_avatar": "https://secure.gravatar.com/avatar/d1a4df204cd9d900bd92207459885b9d?s=80&d=identicon",
-      "project_id": 456789,
-      "project": {
-      "id": 456789,
-      "name": "repository",
-      "description": "",
-      "web_url": "https://gitlab.com/username-or-group/repository",
-      "avatar_url": null,
-      "git_ssh_url": "git@gitlab.com:username-or-group/repository.git",
-      "git_http_url": "https://gitlab.com/username-or-group/repository.git",
-      "namespace": "namespace",
-      "visibility_level": 0,
-      "path_with_namespace": "username-or-group/repository",
-      "default_branch": "main",
-      "ci_config_path": "",
-      "homepage": "https://gitlab.com/username-or-group/repository",
-      "url": "git@gitlab.com:username-or-group/repository.git",
-      "ssh_url": "git@gitlab.com:username-or-group/repository.git",
-      "http_url": "https://gitlab.com/username-or-group/repository.git"
-      },
-      "commits": [
-      {
-      "id": "ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
-      "message": "debug: update\\n",
-      "title": "debug: update",
-      "timestamp": "2024-01-06T00:43:53+01:00",
-      "url": "https://gitlab.com/username-or-group/repository/-/commit/ea6c525a17d2c6f23ebd36b2acfbfb1eb7b36cd1",
-      "author": {
-      "name": "MY NAME",
-      "email": "[REDACTED]"
-      },
-      "added": [
-
-      ],
-      "modified": [
-      "script.user.js"
-      ],
-      "removed": [
-
-      ]
-      }
-      ],
-      "total_commits_count": 1,
-      "push_options": {
-      },
-      "repository": {
-      "name": "repository",
-      "url": "git@gitlab.com:username-or-group/repository.git",
-      "description": "",
-      "homepage": "https://gitlab.com/username-or-group/repository",
-      "git_http_url": "https://gitlab.com/username-or-group/repository.git",
-      "git_ssh_url": "git@gitlab.com:username-or-group/repository.git",
-      "visibility_level": 0
-      }
-      }
-    JSON
+    json = PRIVATE_PUSH_BODY
 
     script = Script.find_by(sync_identifier: 'https://github.com/JasonBarnabe/webhooktest/raw/master/test.user.js')
     script.update!(sync_identifier: 'https://gitlab.com/api/v4/projects/456789/repository/files/script.user.js/raw?ref=main&private_token=glpat-XXXX')
@@ -256,5 +258,38 @@ class GitlabWebhookTest < ActionDispatch::IntegrationTest
     push_webhook_request(user, body: json)
     assert_equal '200', response.code
     assert_equal({ 'updated_scripts' => ['https://greasyfork.org/en/scripts/18-mb-funkey-illustrated-records-15'], 'updated_failed' => [] }, response.parsed_body)
+  end
+
+  # A private repo's sync URL must use the API, which only serves a URL-encoded
+  # file path - so a script in a subdirectory is stored with %2F separators.
+  def test_webhook_to_private_url_in_subdirectory
+    json = PRIVATE_PUSH_BODY.sub('"script.user.js"', '"scripts/script.user.js"')
+
+    script = Script.find_by(sync_identifier: 'https://github.com/JasonBarnabe/webhooktest/raw/master/test.user.js')
+    script.update!(sync_identifier: 'https://gitlab.com/api/v4/projects/456789/repository/files/scripts%2Fscript.user.js/raw?ref=main&private_token=glpat-XXXX')
+    ScriptImporter::BaseScriptImporter.expects(:download).with(script.sync_identifier).returns(script.newest_saved_script_version.rewritten_code)
+    user = User.find(1)
+    push_webhook_request(user, body: json)
+    assert_equal '200', response.code
+    assert_equal({ 'updated_scripts' => ['https://greasyfork.org/en/scripts/18-mb-funkey-illustrated-records-15'], 'updated_failed' => [] }, response.parsed_body)
+  end
+
+  # Additional info has its own sync identifier, and a changed file can match only
+  # that - the contents still have to come from the URL rather than a clone.
+  def test_webhook_to_private_url_additional_info
+    json = PRIVATE_PUSH_BODY.sub('"script.user.js"', '"script.md"')
+
+    script = Script.find(18)
+    additional_info = LocalizedScriptAttribute.create!(
+      script:, attribute_key: 'additional_info', attribute_value: 'Old text', attribute_default: true,
+      locale_id: 1, value_markup: 'markdown',
+      sync_identifier: 'https://gitlab.com/api/v4/projects/456789/repository/files/script.md/raw?ref=main&private_token=glpat-XXXX'
+    )
+    ScriptImporter::BaseScriptImporter.expects(:download).with(additional_info.sync_identifier).returns('New text')
+    user = User.find(1)
+    push_webhook_request(user, body: json)
+    assert_equal '200', response.code
+    assert_equal({ 'updated_scripts' => ['https://greasyfork.org/en/scripts/18-a-test'], 'updated_failed' => [] }, response.parsed_body)
+    assert_equal 'New text', additional_info.reload.attribute_value
   end
 end


### PR DESCRIPTION
Push webhooks do not update scripts that sync from a private GitLab project over the API. I hit this with my own repository and traced it to two separate problems.

## 1. Encoded file paths never match

`Gitlab.urls_for_ref` builds the API candidate URL with the path taken straight from the push payload, so it keeps its slashes:

```ruby
{ prefix: "https://gitlab.com/api/v4/projects/#{project_id}/repository/files/#{file}/raw?ref=#{branch}" }
```

The GitLab files API only serves a URL-encoded path. An unencoded one returns 404, so a script in a subdirectory has to be stored with `%2F` separators:

```
built:   .../files/scripts/script.user.js/raw?ref=main
stored:  .../files/scripts%2Fscript.user.js/raw?ref=main
```

`inject_script_info` compares with `sync_identifier LIKE '<prefix>%'`, so the two never match and the delivery answers:

```json
{"updated_scripts":[],"updated_failed":[],"message":"No scripts found."}
```

Manual syncing of the same URL works, because it fetches the stored identifier without any matching. Scripts at the repository root are unaffected, since a name with no slash is identical either way, which is why `test_webhook_to_private_url` passes today.

`urls_for_ref` now offers the encoded form as well. `uniq` keeps the list unchanged for root-level files.

## 2. Additional info files are routed to a clone

`process_webhook_changes` decides between downloading by URL and cloning the repository by inspecting only `info[:scripts]`:

```ruby
pull_from_url, pull_from_git = changed_files.partition { |_k, v| v[:scripts].any? { |s| s.sync_identifier.include?('private_token') } }
```

A changed file that matches only an additional info attribute has no scripts, so it goes to the clone path. On a private repository that fails:

```json
{"message":"Could not pull contents from git: git clone of https://gitlab.com/... failed - fatal: could not read Username for 'https://gitlab.com': No such device or address"}
```

The `rescue` around `Git.get_contents` renders and returns, so a push containing both a script and its additional info file publishes nothing at all, not even the script.

The check now considers script attributes too, and `sync_identifier_for` reads the identifier from whichever record matched.

## Tests

Added two cases to `test/integration/gitlab_webhook_test.rb`, both reusing the existing private push payload, which I extracted into a `PRIVATE_PUSH_BODY` constant:

- `test_webhook_to_private_url_in_subdirectory`
- `test_webhook_to_private_url_additional_info`

Against unmodified code the first fails with `"No scripts found."` and the second errors inside `Git.get_contents`, matching the two symptoms above. With the fix, all 7 tests in the file pass. `bundle exec rubocop` reports no offenses on the changed files.

## Note on release webhooks

`Gitlab.info_from_release_event` looks up scripts with `sync_identifier LIKE '<repo web url>%'`, which an `api/v4/...` identifier never starts with, so release events on a private GitLab repository report "No commits found in this push." regardless of the payload. That needs a different fix, so I have left it out of this PR.
